### PR TITLE
fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Don't look at the code.  It's gross.
 
 ## Install
 
-    go get github.com/joeshaw/iata
+    go install github.com/joeshaw/iata@latest
 
 ## Usage
 


### PR DESCRIPTION
'go get' is no longer supported outside a module.
To build and install a command, use 'go install' with a version, like 'go install example.com/cmd@latest'